### PR TITLE
Remoteprocess migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ elf = "0.0.10"
 failure = "0.1.1"
 flate2 = "0.2.14"
 libc = "0.2.15"
-read-process-memory = "0.1.0"
+remoteprocess = { git = "https://github.com/akhramov/py-spy.git", branch = "feature/copy-vec" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ elf = "0.0.10"
 failure = "0.1.1"
 flate2 = "0.2.14"
 libc = "0.2.15"
-remoteprocess = { git = "https://github.com/akhramov/py-spy.git", branch = "feature/copy-vec" }
+remoteprocess = "0.3.1"


### PR DESCRIPTION
For FreeBSD support in particular, we need to migrate rbspy-testdata
to py-spy's remoteprocess crate.

This change migrates the code from `read_process_memory` to
`remoteprocess` crate.